### PR TITLE
Build docker image for arm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,12 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Prepare
         id: prep
         run: |
@@ -38,6 +44,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.prep.outputs.tags }}
+          platforms: linux/amd64, linux/arm64/v8
           build-args: |
             VERSION=${{ steps.prep.outputs.version }}
             BUILD_DATE=${{ steps.prep.outputs.builddate }}


### PR DESCRIPTION
I want to run the tm server on my raspberry pi, but as it has an arm64 cpu it requires the docker images to be build in this architecture as well. 

Build and deploy the image for amd64 and arm64 cpu architecture.